### PR TITLE
Multi geometries for line and polygon features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .pytest_cache
 .venv
+*.gpkg
+*.gpkg*

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ and use other tools such as `ogr2ogr` to load data into the database.
 
 ## Differences from TA1 schema
 
+Several changes have been made to the TA1 schema to make it more compatible with the GeoPackage structure.
+
 - `extraction_identifier` -> `extraction_pointer`
 - `model` field has been renamed to `pointer` for clarity for linking models
 - `MapFeatureExtractions` is replaced by many-to-one foreign key relationships directly to the `map` table
+- `line_feature` and `polygon_feature` have been converted to `MultiLineString` and `MultiPolygon` types respectively.

--- a/criticalmaas/ta1_geopackage/__init__.py
+++ b/criticalmaas/ta1_geopackage/__init__.py
@@ -2,18 +2,22 @@ from pathlib import Path
 from sqlalchemy import create_engine
 from macrostrat.database.utils import run_sql
 from sqlalchemy import event
+from sqlalchemy.engine import Engine
 
 
 def _fk_pragma_on_connect(dbapi_con, con_record):
     dbapi_con.execute("pragma foreign_keys=ON")
 
 
+def enable_foreign_keys(engine: Engine):
+    event.listen(engine, "connect", _fk_pragma_on_connect)
+
+
 def create_geopackage(filename: Path | str):
     url = "sqlite:///" + str(filename)
     engine = create_engine(url)
 
-    event.listen(engine, "connect", _fk_pragma_on_connect)
-    # event.listen(engine, "connect", load_spatialite_gpkg)
+    enable_foreign_keys(engine)
 
     fixtures = Path(__file__).parent / "fixtures"
     files = sorted(fixtures.glob("*.sql"))

--- a/criticalmaas/ta1_geopackage/fixtures/03-tables.sql
+++ b/criticalmaas/ta1_geopackage/fixtures/03-tables.sql
@@ -53,8 +53,8 @@ CREATE TABLE line_type (
 CREATE TABLE polygon_feature (
   id TEXT PRIMARY KEY, -- for internal linking purposes in this file
   map_id TEXT NOT NULL, -- ID of the containing map
-  map_geom POLYGON NOT NULL, -- polygon geometry, world coordinates
-  px_geom POLYGON, -- polygon geometry, pixel coordinates
+  map_geom MULTIPOLYGON NOT NULL, -- polygon geometry, world coordinates
+  px_geom MULTIPOLYGON, -- polygon geometry, pixel coordinates
   type TEXT, -- polygon type information
   confidence REAL, -- confidence associated with this extraction
   provenance TEXT, -- provenance for this extraction
@@ -66,8 +66,8 @@ CREATE TABLE polygon_feature (
 CREATE TABLE line_feature (
   id TEXT PRIMARY KEY, -- for internal linking purposes in this file
   map_id TEXT NOT NULL, -- ID of the containing map
-  map_geom LINESTRING NOT NULL, -- line geometry, world coordinates
-  px_geom LINESTRING, -- line geometry, pixel coordinates
+  map_geom MULTILINESTRING NOT NULL, -- line geometry, world coordinates
+  --px_geom MULTILINESTRING, -- line geometry, pixel coordinates
   name TEXT, -- name of this map feature
   type TEXT, -- line type information
   polarity INTEGER, -- line polarity
@@ -221,8 +221,8 @@ INSERT INTO gpkg_contents (table_name, data_type, identifier, description)
 
 INSERT INTO gpkg_geometry_columns (table_name, column_name, geometry_type_name, srs_id, z, m)
   VALUES
-  ('polygon_feature', 'map_geom', 'POLYGON', 4326, 0, 0),
-  ('line_feature', 'map_geom', 'LINESTRING', 4326, 0, 0),
+  ('polygon_feature', 'map_geom', 'MULTPOLYGON', 4326, 0, 0),
+  ('line_feature', 'map_geom', 'MULTILINESTRING', 4326, 0, 0),
   ('point_feature', 'map_geom', 'POINT', 4326, 0, 0),
   ('cross_section', 'line_of_section', 'LINESTRING', 4326, 0, 0),
   ('ground_control_point', 'map_geom', 'POINT', 4326, 0, 0),

--- a/criticalmaas/ta1_geopackage/test_create_geopackage.py
+++ b/criticalmaas/ta1_geopackage/test_create_geopackage.py
@@ -68,3 +68,10 @@ def test_write_polygon_feature_to_geopackage(empty_geopackage: Path):
     assert res is not None
     assert res.map_geom is not None
     assert res.map_geom == feature
+
+    # Read the feature back from the database with Fiona
+    import fiona
+
+    with fiona.open(str(empty_geopackage), layer="polygon_feature") as src:
+        assert len(src) == 1
+        assert src[0]["geometry"] == shape(feature)

--- a/criticalmaas/ta1_geopackage/test_create_geopackage.py
+++ b/criticalmaas/ta1_geopackage/test_create_geopackage.py
@@ -1,18 +1,26 @@
 from pathlib import Path
 from macrostrat.utils import working_directory
-from . import create_geopackage
-from macrostrat.database import run_sql
+from . import create_geopackage, enable_foreign_keys
+from macrostrat.database import run_sql, Database
 from sqlalchemy import text
+from pytest import fixture
+from sqlalchemy.engine import Engine
+from typing import Generator
 
 
-def tests_geopackage_file_creation(tmp_path: Path):
-    """Create temporary geopackage file and check that it exists."""
+@fixture(scope="function")
+def empty_geopackage(tmp_path: Path) -> Generator[Path, None, None]:
     with working_directory(str(tmp_path)):
         create_geopackage("test.gpkg")
-        assert Path("test.gpkg").exists()
+        yield tmp_path / "test.gpkg"
 
 
-def test_write_polygon_feature_to_geopackage(tmp_path: Path):
+def tests_geopackage_file_creation(empty_geopackage: Path):
+    """Create temporary geopackage file and check that it exists."""
+    assert empty_geopackage.exists()
+
+
+def test_write_polygon_feature_to_geopackage(empty_geopackage: Path):
     """
     Write polygon data directly to a GeoPackage file
     """
@@ -23,41 +31,40 @@ def test_write_polygon_feature_to_geopackage(tmp_path: Path):
     from shapely.geometry import shape
     from shapely.geometry.base import BaseGeometry
 
-    # Create shapely geometry from WKT
+    # Recreate the database engine
+    db = Database("sqlite:///" + str(empty_geopackage))
+    enable_foreign_keys(db.engine)
+    engine = db.engine
 
-    # Create a GeoPackage file
-    with working_directory(str(tmp_path)):
-        engine = create_geopackage("test.gpkg")
-
-        # Need to create a map and a polygon type before we do anything,
-        # to make sure that foreign keys align
-        run_sql(
-            engine,
-            """
+    # Need to create a map and a polygon type before we do anything,
+    # to make sure that foreign keys align
+    run_sql(
+        engine,
+        """
         INSERT INTO map (id, name, source_url, image_url, image_width, image_height)
-        VALUES ('test', 'test', 'test', 'test', 1, 1);
+        VALUES ('test', 'test', 'test', 'test', -1, -1);
 
         INSERT INTO polygon_type (id, name, color)
         VALUES ('test', 'geologic unit', 'test');
         """,
-            raise_errors=True,
-        )
+        raise_errors=True,
+    )
 
-        # Write the feature to the database
-        # conn.execute(text(sql), dict(geom=geom))
-        run_sql(
-            engine,
-            "INSERT INTO polygon_feature (id, map_id, map_geom) VALUES ('test', 'test', :geom)",
-            params=dict(geom=feature),
-            raise_errors=True,
-        )
+    # Write the feature to the database
+    # conn.execute(text(sql), dict(geom=geom))
+    run_sql(
+        engine,
+        "INSERT INTO polygon_feature (id, map_id, map_geom) VALUES ('test', 'test', :geom)",
+        params=dict(geom=feature),
+        raise_errors=True,
+    )
 
-        # Read the feature back from the database
-        result = run_sql(
-            engine,
-            "SELECT map_geom FROM polygon_feature WHERE id = 'test'",
-        )
-        res = result[0].fetchone()
-        assert res is not None
-        assert res.map_geom is not None
-        assert res.map_geom == feature
+    # Read the feature back from the database
+    result = run_sql(
+        engine,
+        "SELECT map_geom FROM polygon_feature WHERE id = 'test'",
+    )
+    res = result[0].fetchone()
+    assert res is not None
+    assert res.map_geom is not None
+    assert res.map_geom == feature


### PR DESCRIPTION
The `line_feature` and `polygon_feature` tables have been converted to `MultiLineString` and `MultiPolygon` geometries, respectively.  This departs from the [TA1 schemas](https://github.com/DARPA-CRITICALMAAS/schemas/tree/main/ta1) but was done for the following reasons:

1. Easier capture of discontinuous and complex geometries without metadata duplication
2. Improved compatibility with Macrostrat database, which stores these features as multi-geometries